### PR TITLE
v0.3.0-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "virgil-pythia",
-  "version": "0.3.0-alpha.0",
+  "version": "0.3.0-alpha.1",
   "description": "Virgil Pythia SDK allows developers to implement Pythia protocol to create breach-proof passwords, immune to offline and online attacks.",
   "main": "./dist/pythia.cjs.js",
   "module": "./dist/pythia.es.js",

--- a/src/BreachProofPassword.ts
+++ b/src/BreachProofPassword.ts
@@ -1,13 +1,19 @@
-import { NodeBuffer } from './types';
+import { NodeBuffer } from '@virgilsecurity/data-utils';
+
+import { NodeBuffer as BufferType } from './types';
 
 export class BreachProofPassword {
-  readonly salt: NodeBuffer;
-  readonly deblindedPassword: NodeBuffer;
+  readonly salt: BufferType;
+  readonly deblindedPassword: BufferType;
   readonly version: number;
 
-  constructor(salt: NodeBuffer, deblindedPassword: NodeBuffer, version: number) {
-    this.salt = salt;
-    this.deblindedPassword = deblindedPassword;
+  constructor(
+    salt: BufferType | string,
+    deblindedPassword: BufferType | string,
+    version: number,
+  ) {
+    this.salt = BreachProofPassword.toNodeBuffer(salt);
+    this.deblindedPassword = BreachProofPassword.toNodeBuffer(deblindedPassword);
     this.version = version;
   }
 
@@ -17,5 +23,15 @@ export class BreachProofPassword {
       deblindedPassword: this.deblindedPassword.toString('base64'),
       version: this.version,
     };
+  }
+
+  private static toNodeBuffer(value: BufferType | string) {
+    if (NodeBuffer.isBuffer(value)) {
+      return value;
+    }
+    if (typeof value === 'string') {
+      return NodeBuffer.from(value, 'base64');
+    }
+    throw new TypeError('`value` should be a Buffer or a string');
   }
 }

--- a/src/BreachProofPassword.ts
+++ b/src/BreachProofPassword.ts
@@ -7,11 +7,7 @@ export class BreachProofPassword {
   readonly deblindedPassword: BufferType;
   readonly version: number;
 
-  constructor(
-    salt: BufferType | string,
-    deblindedPassword: BufferType | string,
-    version: number,
-  ) {
+  constructor(salt: BufferType | string, deblindedPassword: BufferType | string, version: number) {
     this.salt = BreachProofPassword.toNodeBuffer(salt);
     this.deblindedPassword = BreachProofPassword.toNodeBuffer(deblindedPassword);
     this.version = version;


### PR DESCRIPTION
`BreachProofPassword` accepts `Buffer | string` for `salt` and `deblindedPassword`:
- https://github.com/VirgilSecurity/virgil-pythia-node/blob/v0.2.7/src/pythia/BreachProofPassword.js#L16
- https://github.com/VirgilSecurity/virgil-pythia-node/blob/v0.2.7/src/pythia/BreachProofPassword.js#L35

Also it is used in https://github.com/VirgilSecurity/virgil-passport-pythia/blob/master/src/PythiaStrategy.ts#L5